### PR TITLE
Fixed an issue where files with more than 64MB could not be uploaded

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,5 @@
 const azure = require('azure-storage')
-
+const Duplex = require('stream').Duplex;
 module.exports = function (reporter, definition) {
   if (reporter.options.blobStorage.provider !== 'azure-storage') {
     definition.options.enabled = false
@@ -34,7 +34,10 @@ module.exports = function (reporter, definition) {
     read: (blobName) => blobService.createReadStream(options.container, blobName),
     write: (blobName, buffer) => {
       return new Promise((resolve, reject) => {
-        blobService.createBlockBlobFromText(options.container, blobName, buffer, (err, responseBlob, response) => {
+        let stream = new Duplex();
+        stream.push(buffer);
+        stream.push(null);
+        blobService.createBlockBlobFromStream(options.container, blobName, stream, stream.readableLength, (err, responseBlob, response) => {
           if (err) {
             return reject(err)
           }


### PR DESCRIPTION
If a report is bigger than 64MB, the following error is thrown from the azure-storage library:
```RangeError: createBlockBlobFromText requires the size of text to be less than 64MB. Please use createBlockBlobFromLocalFile or createBlockBlobFromStream to upload large blobs.```

This PR changes the usage of createBlockBlobFromText to createBlockBlobFromStream by creating an stream out of the incoming buffer/uint8array